### PR TITLE
tests: drop vestigial importorskip guards

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,12 @@
 
 These tests exercise the *installed wheel* (the public `rt` API + the compiled
 `rt._rustler` engine), so run them against a built + installed package -- e.g.
-`local/test.sh`, or the CI `test` job. torch/polars-dependent tests skip
-cleanly when those aren't present.
+`local/test.sh`, or the CI `test` job.
+
+Every dependency these tests touch is declared -- torch is a hard dependency of
+the package, polars and pytest come from the `test` extra -- so they import
+plainly. A missing one is a broken environment and should fail at collection,
+not vanish into a skip.
 """
 
 from __future__ import annotations
@@ -27,7 +31,6 @@ def tiny_checkpoint(tmp_path, tiny_dims):
 
     Returns ``(checkpoint_dir, source_model)``.
     """
-    pytest.importorskip("torch")
     from rt import RelationalTransformer
     from rt.checkpoints import CONFIG_FILE, MODEL_FILE, save_model
 
@@ -53,7 +56,7 @@ def synthetic_dataset(tmp_path):
     into the entity table. Column dtypes cover the branches ``normalize_df``
     dispatches on -- string, int, float, bool, and datetime.
     """
-    pl = pytest.importorskip("polars")
+    import polars as pl
     import yaml
 
     n_users, n_events = 10, 18

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import json
 
-import pytest
+import torch
 
-torch = pytest.importorskip("torch")
-
-from rt import RelationalTransformer  # noqa: E402
-from rt.checkpoints import (  # noqa: E402
+from rt import RelationalTransformer
+from rt.checkpoints import (
     CONFIG_FILE,
     LEGACY_MODEL_FILE,
     MODEL_FILE,


### PR DESCRIPTION
Follow-up to #9, split out so that PR stayed a clean restoration.

## Why

`tests/` guarded three imports with `pytest.importorskip`, on the policy stated
in the conftest docstring: *"torch/polars-dependent tests skip cleanly when
those aren't present."* That is a reasonable policy for genuinely optional
dependencies, but none of the guarded ones are optional:

- **torch** is a hard dependency of the package (`pyproject.toml`, top of
  `[project].dependencies`). Any valid install has it.
- **polars** and **pytest** come from the `test` extra. If you are running
  pytest at all, you installed it.

So the guards can only fire in an environment that is already broken — and in
that case the suite reports a *skip*, not a failure. There is no CI in this repo
(no `.github/`, and none in history) and the `local/test.sh` the docstring points
at is gitignored, so nothing anywhere asserts "0 skipped". A `pixi run test` that
silently prints `8 passed, 1 skipped` because torch failed to import is
indistinguishable from success.

That is not hypothetical: it is exactly how the `plurel` skip kept
`test_preprocess_end_to_end` dark until #9.

## What changed

- Plain imports throughout; a missing dependency now fails at collection.
- In `test_api.py` the guard was also what forced the real imports below
  module-level code, so removing it retires two `# noqa: E402` suppressions and
  the now-unused `pytest` import.
- Rewrote the conftest docstring, which was asserting the policy being removed.

The one guard that was ever load-bearing — `pyarrow`, an optional pandas parquet
backend — already went away with the polars fixture rewrite in #9.

## Behavior change

Running `pytest` directly outside the pixi env without the `test` extra now
raises a collection error instead of skipping. That is the intent, but it is a
real change for anyone invoking pytest by hand.

## Testing

`pixi run test`: **9 passed**, 0 skipped.